### PR TITLE
fix showing incorrect asset type on asset detail page

### DIFF
--- a/src/js/Transaction.ts
+++ b/src/js/Transaction.ts
@@ -79,6 +79,8 @@ export class Transaction implements ITransaction {
     validatorStart: number
     validatorEnd: number
     txBlockId: string
+    nft: number
+    variableCap: number
 
     constructor(data: TransactionResponse) {
         this.id = data.id
@@ -114,6 +116,8 @@ export class Transaction implements ITransaction {
         this.validatorStart = data.validatorStart
         this.validatorEnd = data.validatorEnd
         this.txBlockId = data.txBlockId
+        this.nft = data.nft
+        this.variableCap = data.variableCap
     }
 
     getInputAddresses(): string[] {

--- a/src/store/modules/transactions/models.ts
+++ b/src/store/modules/transactions/models.ts
@@ -47,6 +47,9 @@ export interface TransactionResponse {
 
     genesis: boolean
 
+    nft: number
+    variableCap: number
+
     /*
     REWARD PATTERNS - tx type: delgator/validator only
         


### PR DESCRIPTION
fixes #107 

It looks like the api returns asset as variable cap, but since the nft and variableCap fields from the response are NOT mapped to TransactionResponse and Transaction, the assets' type is default to fixed cap