### PR TITLE
fix: redirect to absolute path for explorer.avax.network 

### DIFF
--- a/.env
+++ b/.env
@@ -6,8 +6,8 @@ VUE_APP_DEFAULT_NETWORKID=1
 # MAINNET
 # --------------
 VUE_APP_NETWORKNAME=Avalanche
-VUE_APP_EXPLORER_FE_URL=https://explorer-xp.avax.network
-VUE_APP_CCHAIN_EXPLORER_URL=https://snowtrace.io/
+VUE_APP_EXPLORER_FE_URL=https://explorer.avax.network
+VUE_APP_CCHAIN_EXPLORER_URL=https://explorer.avax.network
 VUE_APP_STATUS_URL=https://status.avax.network
 
 VUE_APP_AVAXID=FvwEAhmxKfeiG8SnEvq42hc6whRyY3EFYAvebMqDNDGCgxN5Z
@@ -32,8 +32,8 @@ VUE_APP_AVALANCHE_JS_CHAINID=X
 # TESTNET
 # --------------
 VUE_APP_TEST_NETWORKNAME=Fuji
-VUE_APP_TEST_EXPLORER_FE_URL=https://explorer-xp.avax-test.network
-VUE_APP_TEST_CCHAIN_EXPLORER_URL=https://testnet.snowtrace.io/
+VUE_APP_TEST_EXPLORER_FE_URL=https://explorer.avax-test.network
+VUE_APP_TEST_CCHAIN_EXPLORER_URL=https://explorer.avax-test.network
 VUE_APP_TEST_STATUS_URL=https://status.avax.network
 
 VUE_APP_TEST_AVAXID=U8iRqJoiJm8xZHAacmvYyZVwqQx6uDNtQeP3CQ6fcgQk3JqnK

--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+# DEPRECATION NOTICE
+
+This project is in **deprecated** and, and the Avalanche Explorer is in the process of being migrated to this [React App](https://github.com/ava-labs/explorer-v2) instead. As such, some URLs will redirect to the new explorer experience as it is developed, starting with the HomePage and C-Chain pages. See [this PR](https://github.com/ava-labs/avalanche-explorer/pull/157) for more details.
+
 # Avalanche Explorer
 
 Frontend Vue.js application for displaying Avalanche network activity and blockchains data from the [Ortelius indexer](https://github.com/ava-labs/ortelius) and [Avalanche-Go client](https://github.com/ava-labs/gecko).

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # DEPRECATION NOTICE
 
-This project is in **deprecated**, and the Avalanche Explorer is in the process of being migrated to this [React App](https://github.com/ava-labs/explorer-v2) instead. As such, some URLs will redirect to the new explorer experience as it is developed, starting with the Home page and C-Chain page. See [this PR](https://github.com/ava-labs/avalanche-explorer/pull/157) for more details.
+This project is in **deprecated**, and the Avalanche Explorer is in the process of being migrated to this [React App](https://github.com/ava-labs/explorer-v2) instead. As such, some URLs will redirect to the new explorer experience as it is developed, starting with the Home page and C-Chain page.
 
 # Avalanche Explorer
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # DEPRECATION NOTICE
 
-This project is in **deprecated** and, and the Avalanche Explorer is in the process of being migrated to this [React App](https://github.com/ava-labs/explorer-v2) instead. As such, some URLs will redirect to the new explorer experience as it is developed, starting with the HomePage and C-Chain pages. See [this PR](https://github.com/ava-labs/avalanche-explorer/pull/157) for more details.
+This project is in **deprecated**, and the Avalanche Explorer is in the process of being migrated to this [React App](https://github.com/ava-labs/explorer-v2) instead. As such, some URLs will redirect to the new explorer experience as it is developed, starting with the Home page and C-Chain page. See [this PR](https://github.com/ava-labs/avalanche-explorer/pull/157) for more details.
 
 # Avalanche Explorer
 

--- a/src/components/Footer.vue
+++ b/src/components/Footer.vue
@@ -23,7 +23,7 @@
             <div class="lists">
                 <div class="list">
                     <h4>Menu</h4>
-                    <router-link to="/">Home</router-link>
+                    <a :href="cChainURL">Home</a>
                     <router-link to="/subnets">Subnets</router-link>
                     <router-link to="/validators">Validators</router-link>
                     <router-link to="/assets">Assets</router-link>

--- a/src/components/NavBar.vue
+++ b/src/components/NavBar.vue
@@ -10,7 +10,7 @@
     >
         <div class="top">
             <div class="logo">
-                <router-link to="/">
+                <a :href="cChainURL">
                     <img
                         style="height: 30px"
                         :src="
@@ -20,12 +20,12 @@
                     <h1>
                         <span class="hide">Avalanche Explorer</span>
                     </h1>
-                </router-link>
+                </a>
             </div>
             <v-spacer class="spacer_mid"></v-spacer>
             <div class="links">
                 <div class="routes">
-                    <router-link to="/">Home</router-link>
+                    <a :href="cChainURL">Home</a>
                     <router-link to="/subnets">Subnets</router-link>
                     <router-link to="/validators">Validators</router-link>
                     <a :href="tokensURL">Tokens</a>

--- a/src/components/NavBarMobile.vue
+++ b/src/components/NavBarMobile.vue
@@ -3,7 +3,7 @@
         <!--   TOOLBAR    -->
         <div class="inner">
             <div class="logo">
-                <router-link to="/">
+                <a :href="cChainURL">
                     <img
                         style="height: 20px"
                         :src="
@@ -11,7 +11,7 @@
                         "
                     />
                     <h1><span class="hide">Avalanche Explorer</span></h1>
-                </router-link>
+                </a>
             </div>
             <div class="buttons">
                 <NetworkMenu />
@@ -37,7 +37,7 @@
                     </div>
                 </v-list-item>
                 <template>
-                    <v-list-item to="/">Home</v-list-item>
+                    <v-list-item :href="cChainURL">Home</v-list-item>
                     <v-list-item to="/subnets">Subnets</v-list-item>
                     <v-list-item to="/validators">Validators</v-list-item>
                     <v-list-item :href="tokensURL">Tokens</v-list-item>

--- a/src/components/NavBarSide.vue
+++ b/src/components/NavBarSide.vue
@@ -1,7 +1,7 @@
 <template>
     <div class="navbar_side">
         <v-list dense nav>
-            <v-list-item to="/">Home</v-list-item>
+            <v-list-item :href="cChainURL">Home</v-list-item>
             <v-list-item to="/subnets">Subnets</v-list-item>
             <v-list-item to="/validators">Validators</v-list-item>
             <v-list-item to="/blockchains">Blockchains</v-list-item>

--- a/src/components/NavBarXL.vue
+++ b/src/components/NavBarXL.vue
@@ -10,7 +10,8 @@
     >
         <!-- LEFT -->
         <div class="logo">
-            <router-link to="/">
+            <!-- Just hardcoding to mainnet explorer since this file isn't used -->
+            <a href="https://explorer.avax.network/">
                 <img
                     style="height: 31px"
                     src="@/assets/explorer_logo_black.png"
@@ -18,7 +19,7 @@
                 <h1>
                     <span class="hide">Avalanche Explorer</span>
                 </h1>
-            </router-link>
+            </a>
         </div>
         <v-spacer class="spacer_mid"></v-spacer>
         <!-- MIDDLE -->

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -29,6 +29,9 @@ const routes = [
             title: 'View All Activities' + suffix,
             metaTags: defaultMetaTags,
         },
+        beforeEnter() {
+            window.location.href = 'https://explorer.avax.network/'
+        },
     },
     {
         path: '/subnets',

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -2,6 +2,11 @@ import Vue from 'vue'
 import VueRouter from 'vue-router'
 import Home from '../views/Home.vue'
 import { IMetaTag } from '@/router/IMetaTag'
+import {
+    DEFAULT_NETWORK_ID,
+    cChainExplorerURL,
+    cChainExplorerURL_test,
+} from '@/store/modules/network/network'
 
 Vue.use(VueRouter)
 
@@ -19,6 +24,9 @@ const defaultMetaTags: IMetaTag[] = [
     },
 ]
 
+const cChainURL =
+    DEFAULT_NETWORK_ID === 1 ? cChainExplorerURL : cChainExplorerURL_test
+
 const routes = [
     {
         path: '/',
@@ -30,7 +38,7 @@ const routes = [
             metaTags: defaultMetaTags,
         },
         beforeEnter() {
-            window.location.href = 'https://explorer.avax.network/'
+            window.location.href = cChainURL
         },
     },
     {

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -38,7 +38,9 @@ const routes = [
             metaTags: defaultMetaTags,
         },
         beforeEnter() {
-            window.location.href = cChainURL
+            if (window.location.href !== cChainURL) {
+                window.location.href = cChainURL
+            }
         },
     },
     {


### PR DESCRIPTION
When navigating home, instead navigate to the new explorer-v2 homepage.