### PR TITLE
feat: update cchain url

### DIFF
--- a/.env
+++ b/.env
@@ -7,7 +7,7 @@ VUE_APP_DEFAULT_NETWORKID=1
 # --------------
 VUE_APP_NETWORKNAME=Avalanche
 VUE_APP_EXPLORER_FE_URL=https://explorer.avax.network
-VUE_APP_CCHAIN_EXPLORER_URL=https://explorer.avax.network
+VUE_APP_CCHAIN_EXPLORER_URL=https://subnets.avax.network/c-chain
 VUE_APP_STATUS_URL=https://status.avax.network
 
 VUE_APP_AVAXID=FvwEAhmxKfeiG8SnEvq42hc6whRyY3EFYAvebMqDNDGCgxN5Z

--- a/.env
+++ b/.env
@@ -6,7 +6,7 @@ VUE_APP_DEFAULT_NETWORKID=1
 # MAINNET
 # --------------
 VUE_APP_NETWORKNAME=Avalanche
-VUE_APP_EXPLORER_FE_URL=https://explorer.avax.network
+VUE_APP_EXPLORER_FE_URL=https://subnets.avax.network
 VUE_APP_CCHAIN_EXPLORER_URL=https://subnets.avax.network/c-chain
 VUE_APP_STATUS_URL=https://status.avax.network
 
@@ -32,8 +32,8 @@ VUE_APP_AVALANCHE_JS_CHAINID=X
 # TESTNET
 # --------------
 VUE_APP_TEST_NETWORKNAME=Fuji
-VUE_APP_TEST_EXPLORER_FE_URL=https://explorer.avax-test.network
-VUE_APP_TEST_CCHAIN_EXPLORER_URL=https://explorer.avax-test.network
+VUE_APP_TEST_EXPLORER_FE_URL=https://subnets-test.avax.network
+VUE_APP_TEST_CCHAIN_EXPLORER_URL=https://subnets-test.avax.network/c-chain
 VUE_APP_TEST_STATUS_URL=https://status.avax.network
 
 VUE_APP_TEST_AVAXID=U8iRqJoiJm8xZHAacmvYyZVwqQx6uDNtQeP3CQ6fcgQk3JqnK

--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ Frontend Vue.js application for displaying Avalanche network activity and blockc
 
 When you go to the app on your browser, you might get a warning saying "Site is not secure." This is because we are signing our own SSL Certificates. Please ignore and continue to the website.
 
+The homepage currently redirects to the subnet explorer so to view the app you'll need to go to a specific blockchain url such as: `https://localhost:8081/blockchain/11111111111111111111111111111111LpoYY`
+
 ## Configuration
 
 See `.env`. By default, the Avalanche Explorer interfaces with the Everest test network.

--- a/public/index.html
+++ b/public/index.html
@@ -7,7 +7,7 @@
     <meta name="description" content="Avalanche Explorer is an analytics tool that enables people to search the Avalanche blockchain for transactions, addresses, and other platform activities." vue-router-data="">
     <meta property="og:description" content="Avalanche Explorer is an analytics tool that enables people to search the Avalanche blockchain for transactions, addresses, and other platform activities." vue-router-data="">
     <meta property="og:image" content="<%= BASE_URL %>og-image-avalanche.png">
-    <meta property="og:url" content="https://explorer-xp.avax.network/">
+    <meta property="og:url" content="https://explorer-xp.avax.network/subnets/">
     <meta property="og:type" content="website">
     <title>Avalanche Explorer</title>
     <link rel="icon" href="<%= BASE_URL %>favicon.ico">

--- a/public/index.html
+++ b/public/index.html
@@ -7,8 +7,8 @@
     <meta name="description" content="Avalanche Explorer is an analytics tool that enables people to search the Avalanche blockchain for transactions, addresses, and other platform activities." vue-router-data="">
     <meta property="og:description" content="Avalanche Explorer is an analytics tool that enables people to search the Avalanche blockchain for transactions, addresses, and other platform activities." vue-router-data="">
     <meta property="og:image" content="<%= BASE_URL %>og-image-avalanche.png">
-    <meta property="og:url" content="https://explorer.avax.network/">
-    <meta property="og:type" content="website">    
+    <meta property="og:url" content="https://explorer-xp.avax.network/">
+    <meta property="og:type" content="website">
     <title>Avalanche Explorer</title>
     <link rel="icon" href="<%= BASE_URL %>favicon.ico">
     <!-- <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:100,300,400,500,700,900"> -->

--- a/src/components/Footer.vue
+++ b/src/components/Footer.vue
@@ -23,7 +23,7 @@
             <div class="lists">
                 <div class="list">
                     <h4>Menu</h4>
-                    <a :href="cChainURL">Home</a>
+                    <a :href="explorerFEUrl">Home</a>
                     <router-link to="/subnets">Subnets</router-link>
                     <router-link to="/validators">Validators</router-link>
                     <router-link to="/assets">Assets</router-link>
@@ -43,7 +43,10 @@
                     <a href="https://reddit.com/r/avax" target="_blank">
                         <fa :icon="['fab', 'reddit']"></fa>Reddit
                     </a>
-                    <a href="https://github.com/ava-labs/avalanche-explorer" target="_blank">
+                    <a
+                        href="https://github.com/ava-labs/avalanche-explorer"
+                        target="_blank"
+                    >
                         <fa :icon="['fab', 'github']"></fa>GitHub
                     </a>
                 </div>
@@ -58,6 +61,8 @@ import {
     DEFAULT_NETWORK_ID,
     cChainExplorerURL,
     cChainExplorerURL_test,
+    explorerFEUrl,
+    explorerFEUrl_test,
     statusURL,
     statusURL_test,
 } from '@/store/modules/network/network'
@@ -68,6 +73,10 @@ export default class Footer extends Vue {
         return DEFAULT_NETWORK_ID === 1
             ? cChainExplorerURL
             : cChainExplorerURL_test
+    }
+
+    get explorerFEUrl() {
+        return DEFAULT_NETWORK_ID === 1 ? explorerFEUrl : explorerFEUrl_test
     }
 
     get statusPageURL() {

--- a/src/components/NavBar.vue
+++ b/src/components/NavBar.vue
@@ -10,7 +10,7 @@
     >
         <div class="top">
             <div class="logo">
-                <a :href="cChainURL">
+                <a :href="explorerFEUrl">
                     <img
                         style="height: 30px"
                         :src="
@@ -25,7 +25,7 @@
             <v-spacer class="spacer_mid"></v-spacer>
             <div class="links">
                 <div class="routes">
-                    <a :href="cChainURL">Home</a>
+                    <a :href="explorerFEUrl">Home</a>
                     <router-link to="/subnets">Subnets</router-link>
                     <router-link to="/validators">Validators</router-link>
                     <a :href="tokensURL">Tokens</a>
@@ -80,6 +80,8 @@ import {
     cChainExplorerURL_test,
     statusURL,
     statusURL_test,
+    explorerFEUrl,
+    explorerFEUrl_test,
 } from '@/store/modules/network/network'
 import { PlatformGettersMixin } from '@/store/modules/platform/platform.mixins'
 import { getMarketCapUSD } from '@/store/modules/platform/platform.getters'
@@ -108,6 +110,11 @@ export default class Navbar extends Mixins(PlatformGettersMixin) {
     get logoColor() {
         return DEFAULT_NETWORK_ID === 1 ? 'black' : 'white'
     }
+
+    get explorerFEUrl() {
+        return DEFAULT_NETWORK_ID === 1 ? explorerFEUrl : explorerFEUrl_test
+    }
+
     get cChainURL() {
         return DEFAULT_NETWORK_ID === 1
             ? cChainExplorerURL

--- a/src/components/NavBarMobile.vue
+++ b/src/components/NavBarMobile.vue
@@ -3,7 +3,7 @@
         <!--   TOOLBAR    -->
         <div class="inner">
             <div class="logo">
-                <a :href="cChainURL">
+                <a :href="explorerFEUrl">
                     <img
                         style="height: 20px"
                         :src="
@@ -37,7 +37,7 @@
                     </div>
                 </v-list-item>
                 <template>
-                    <v-list-item :href="cChainURL">Home</v-list-item>
+                    <v-list-item :href="explorerFEUrl">Home</v-list-item>
                     <v-list-item to="/subnets">Subnets</v-list-item>
                     <v-list-item to="/validators">Validators</v-list-item>
                     <v-list-item :href="tokensURL">Tokens</v-list-item>
@@ -81,6 +81,8 @@ import {
     DEFAULT_NETWORK_ID,
     cChainExplorerURL,
     cChainExplorerURL_test,
+    explorerFEUrl,
+    explorerFEUrl_test,
     statusURL,
     statusURL_test,
 } from '@/store/modules/network/network'
@@ -115,6 +117,10 @@ export default class NavbarMobile extends Vue {
         return DEFAULT_NETWORK_ID === 1
             ? cChainExplorerURL
             : cChainExplorerURL_test
+    }
+
+    get explorerFEUrl() {
+        return DEFAULT_NETWORK_ID === 1 ? explorerFEUrl : explorerFEUrl_test
     }
 
     get tokensURL() {

--- a/src/components/NavBarSide.vue
+++ b/src/components/NavBarSide.vue
@@ -1,7 +1,7 @@
 <template>
     <div class="navbar_side">
         <v-list dense nav>
-            <v-list-item :href="cChainURL">Home</v-list-item>
+            <v-list-item :href="explorerFEUrl">Home</v-list-item>
             <v-list-item to="/subnets">Subnets</v-list-item>
             <v-list-item to="/validators">Validators</v-list-item>
             <v-list-item to="/blockchains">Blockchains</v-list-item>
@@ -20,6 +20,8 @@ import {
     DEFAULT_NETWORK_ID,
     cChainExplorerURL,
     cChainExplorerURL_test,
+    explorerFEUrl,
+    explorerFEUrl_test,
     statusURL,
     statusURL_test,
 } from '@/store/modules/network/network'
@@ -30,6 +32,10 @@ export default class NavbarSide extends Vue {
         return DEFAULT_NETWORK_ID === 1
             ? cChainExplorerURL
             : cChainExplorerURL_test
+    }
+
+    get explorerFEUrl() {
+        return DEFAULT_NETWORK_ID === 1 ? explorerFEUrl : explorerFEUrl_test
     }
 
     get statusPageURL() {

--- a/src/components/NavBarXL.vue
+++ b/src/components/NavBarXL.vue
@@ -11,7 +11,7 @@
         <!-- LEFT -->
         <div class="logo">
             <!-- Just hardcoding to mainnet explorer since this file isn't used -->
-            <a href="https://explorer.avax.network/">
+            <a href="https://subnets.avax.network/">
                 <img
                     style="height: 31px"
                     src="@/assets/explorer_logo_black.png"

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -4,8 +4,8 @@ import Home from '../views/Home.vue'
 import { IMetaTag } from '@/router/IMetaTag'
 import {
     DEFAULT_NETWORK_ID,
-    cChainExplorerURL,
-    cChainExplorerURL_test,
+    explorerFEUrl,
+    explorerFEUrl_test,
 } from '@/store/modules/network/network'
 
 Vue.use(VueRouter)
@@ -24,8 +24,8 @@ const defaultMetaTags: IMetaTag[] = [
     },
 ]
 
-const cChainURL =
-    DEFAULT_NETWORK_ID === 1 ? cChainExplorerURL : cChainExplorerURL_test
+const explorerFEURL =
+    DEFAULT_NETWORK_ID === 1 ? explorerFEUrl : explorerFEUrl_test
 
 const routes = [
     {
@@ -38,8 +38,8 @@ const routes = [
             metaTags: defaultMetaTags,
         },
         beforeEnter() {
-            if (window.location.href !== cChainURL) {
-                window.location.href = cChainURL
+            if (window.location.href !== explorerFEURL) {
+                window.location.href = explorerFEURL
             }
         },
     },

--- a/src/store/modules/network/network.ts
+++ b/src/store/modules/network/network.ts
@@ -15,7 +15,7 @@ export const DEFAULT_NETWORK_NAME =
 
 // Mainnet
 const networkName = process.env.VUE_APP_NETWORKNAME
-const explorerFEUrl = process.env.VUE_APP_EXPLORER_FE_URL || ''
+export const explorerFEUrl = process.env.VUE_APP_EXPLORER_FE_URL || ''
 const orteliusURL = process.env.VUE_APP_ORTELIUS_URL || ''
 export const ethereumAPI = process.env.VUE_APP_AVALANCHE_GO_ETH_URL || ''
 export const peerInfoURL = process.env.VUE_APP_PEER_INFO_URL || ''
@@ -31,7 +31,7 @@ export const statusURL = process.env.VUE_APP_STATUS_URL || ''
 
 // Testnet
 const networkName_test = process.env.VUE_APP_TEST_NETWORKNAME || ''
-const explorerFEUrl_test = process.env.VUE_APP_TEST_EXPLORER_FE_URL || ''
+export const explorerFEUrl_test = process.env.VUE_APP_TEST_EXPLORER_FE_URL || ''
 const orteliusURL_test = process.env.VUE_APP_TEST_ORTELIUS_URL || ''
 export const ethereumAPI_test =
     process.env.VUE_APP_TEST_AVALANCHE_GO_ETH_URL || ''


### PR DESCRIPTION
This PR does the following:
- Updates the `VUE_APP_CCHAIN_EXPLORER_URL` env variable to point to `https://subnets.avax.network/c-chain`
- Update the `oh:url` prop with the correct url
- adds a comment in the README