### PR TITLE
feat: load subnets in chunks to avoid failures

### DIFF
--- a/src/store/modules/platform/helpers/chunkRunner.ts
+++ b/src/store/modules/platform/helpers/chunkRunner.ts
@@ -1,0 +1,16 @@
+export const chunkRunner = (
+    data: any[],
+    chunkSize: number,
+    timeout: number,
+    callback: Function
+) => {
+    const numChunks = Math.ceil(data.length / chunkSize)
+    for (let index = 0; index < numChunks; index++) {
+        const chunk = data.slice(index * chunkSize, chunkSize * (index + 1))
+        const isLastRun = index >= numChunks - 1
+
+        setTimeout(() => {
+            callback(chunk, isLastRun)
+        }, timeout * index)
+    }
+}

--- a/src/store/modules/platform/helpers/index.ts
+++ b/src/store/modules/platform/helpers/index.ts
@@ -1,1 +1,2 @@
 export * from './calculateStakingReward'
+export * from './chunkRunner'

--- a/src/store/modules/platform/platform.ts
+++ b/src/store/modules/platform/platform.ts
@@ -11,27 +11,10 @@ import Blockchain from '@/js/Blockchain'
 import { C, P } from '@/known_blockchains'
 import { getAddressCounts } from '@/services/addressCounts/addressCounts.service'
 import { AddressCount } from '@/services/addressCounts/models'
-import { calculateStakingReward } from './helpers'
+import { calculateStakingReward, chunkRunner } from './helpers'
 import { getTxCounts } from '@/services/transactionCounts/transactionCounts.service'
 import { TxCount } from '@/services/transactionCounts/models'
 import { getBurnedC } from '@/services/burned/burned.service'
-
-export const chunkRunner = (
-    data: any[],
-    chunkSize: number,
-    timeout: number,
-    callback: Function
-) => {
-    const numChunks = Math.ceil(data.length / chunkSize)
-    for (let index = 0; index < numChunks; index++) {
-        const chunk = data.slice(index * chunkSize, chunkSize * (index + 1))
-        const isLastRun = index >= numChunks - 1
-
-        setTimeout(() => {
-            callback(chunk, isLastRun)
-        }, timeout * index)
-    }
-}
 
 export const AVALANCHE_SUBNET_ID = P.id
 
@@ -100,7 +83,7 @@ const platform_module: Module<PlatformState, IRootState> = {
                 {}
             )
 
-            chunkRunner(subnets, 1, 5, (chunk: Subnet[]) => {
+            chunkRunner(subnets, 5, 25, (chunk: Subnet[]) => {
                 chunk.forEach((s) => {
                     s.updateValidators('platform.getCurrentValidators')
                     s.updateValidators('platform.getPendingValidators')


### PR DESCRIPTION
This PR fixes the issue that was causing the testnet  explorer to not load.
The issue was that the following code was looping through all subnets and making several requests to the server for each.
There were 905 requests and this would cause all of them to fail.
The PR adds a `chunkRunner` function to run each reqeust every 5ms, which removes the bottleneck and allows them to load.

```
const subnets = ((await platform.getSubnets()) as ISubnetData[]).map(
    (s: ISubnetData) => new Subnet(s)
)

// Get and set validators for each subnet
subnets.forEach((s) => {
    s.updateValidators('platform.getCurrentValidators')
    s.updateValidators('platform.getPendingValidators')
    commit('setSubnet', s)
})
```

One thing to note is that the `Subnets` and `Blockchains` count will start at 0 and climb up to 900+ as each request completes.

<img width="912" alt="image" src="https://user-images.githubusercontent.com/16954412/181799004-035cc758-4dbb-405b-9a72-b981ac08d91d.png">
